### PR TITLE
Add XPU CI pipeline for dynamo builds

### DIFF
--- a/.github/actions/bootstrap-buildkit/action.yml
+++ b/.github/actions/bootstrap-buildkit/action.yml
@@ -1,0 +1,160 @@
+name: 'Bootstrap Buildkit'
+description: 'Bootstrap buildkit builders using remote workers or Kubernetes driver'
+
+# This action supports two buildkit driver modes:
+#
+# 1. Remote Driver (when buildkit_worker_addresses is provided)
+#    Uses pre-provisioned remote buildkit workers specified via buildkit_worker_addresses.
+#    This is the preferred mode for faster, more reliable builds.
+#
+# 2. Kubernetes Driver (fallback, when buildkit_worker_addresses is empty)
+#    Dynamically creates buildkit pods in Kubernetes. Use this as a fallback when
+#    remote buildkit workers are unavailable or unreachable. The Kubernetes driver
+#    is slower due to pod startup time but provides on-demand build capacity.
+#
+# Options:
+#   - skip_bootstrap: Set to 'true' to only create the builder without bootstrapping.
+#     Useful for cleanup jobs that need to remove the builder but not bootstrap it.
+
+inputs:
+  builder_name:
+    description: 'Name for the buildx builder'
+    required: true
+  buildkit_worker_addresses:
+    description: 'Comma-separated list of remote buildkit worker addresses. If empty, falls back to Kubernetes driver.'
+    required: false
+    default: ''
+  use_runner_docker_builder:
+    description: 'When true and no remote workers are configured, skip Kubernetes builder creation and reuse the runner docker builder.'
+    required: false
+    default: 'false'
+
+
+  # Kubernetes driver inputs (used when remote_builder is false)
+  ephemeral_storage:
+    description: 'Ephemeral storage request for Kubernetes driver'
+    required: false
+    default: '400Gi'
+  namespace:
+    description: 'Kubernetes namespace for buildkit pods'
+    required: false
+    default: 'buildkit'
+  replicas:
+    description: 'Number of buildkit replicas'
+    required: false
+    default: '1'
+  requests_cpu:
+    description: 'CPU requests for buildkit pods'
+    required: false
+    default: '12'
+  requests_memory:
+    description: 'Memory requests for buildkit pods'
+    required: false
+    default: '26Gi'
+  limits_memory:
+    description: 'Memory limits for buildkit pods'
+    required: false
+    default: '29Gi'
+  tolerations:
+    description: 'Tolerations for buildkit pods'
+    required: false
+    default: "key=buildkit-fallback-worker,value=true,operator=Equal,effect=NoSchedule"
+  skip_bootstrap:
+    description: 'Skip the bootstrap step (only create the builder)'
+    required: false
+    default: 'false'
+  suppress_fallback_warning:
+    description: 'Suppress the fallback pod warning when intentionally using the Kubernetes driver'
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify Docker Buildx availability
+      shell: bash
+      run: |
+        docker buildx version
+
+    - name: Use runner docker builder
+      if: inputs.buildkit_worker_addresses == '' && inputs.use_runner_docker_builder == 'true' && inputs.fresh_builder != 'true'
+      shell: bash
+      run: |
+        RESOLVED_BUILDER="default"
+        echo "Using runner docker builder: ${RESOLVED_BUILDER}"
+        docker buildx use "$RESOLVED_BUILDER"
+        echo "BUILDX_BUILDER_NAME=${RESOLVED_BUILDER}" >> "$GITHUB_ENV"
+
+    - name: Define remote buildkit builders
+      if: inputs.buildkit_worker_addresses != ''
+      shell: bash
+      run: |
+        ADDRS="${{ inputs.buildkit_worker_addresses }}"
+        IFS=',' read -ra ADDR_LIST <<< "$ADDRS"
+        FIRST=true
+        for addr in "${ADDR_LIST[@]}"; do
+          if $FIRST; then
+            docker buildx create --use --name ${{ inputs.builder_name }} --driver remote "$addr"
+            FIRST=false
+          else
+            docker buildx create --append --name ${{ inputs.builder_name }} --driver remote "$addr"
+          fi
+        done
+
+    - name: Create Kubernetes builder for both platforms
+      if: inputs.buildkit_worker_addresses == '' && inputs.use_runner_docker_builder != 'true'
+      shell: bash
+      run: |
+        # If the builder already exists, these commands will just set the right configurations to use it
+        echo "🔨 Creating K8s builder '${{ inputs.builder_name }}'."
+        docker buildx create --use --name ${{ inputs.builder_name }} --driver kubernetes --platform=linux/amd64 \
+        '--driver-opt=requests.ephemeral-storage=${{ inputs.ephemeral_storage }}' \
+        '--driver-opt=namespace=${{ inputs.namespace }}' \
+        '--driver-opt=loadbalance=sticky' \
+        '--driver-opt=replicas=${{ inputs.replicas }}' \
+        '--driver-opt=requests.cpu=${{ inputs.requests_cpu }}' \
+        '--driver-opt=requests.memory=${{ inputs.requests_memory }}' \
+        '--driver-opt=limits.memory=${{ inputs.limits_memory }}' \
+        '--driver-opt="nodeselector=kubernetes.io/arch=amd64,role=dynamo-builder-fallback"' \
+        '--driver-opt="tolerations=${{ inputs.tolerations }}"'
+
+        docker buildx create --append --name ${{ inputs.builder_name }} --driver kubernetes --platform=linux/arm64 \
+        '--driver-opt=requests.ephemeral-storage=${{ inputs.ephemeral_storage }}' \
+        '--driver-opt=namespace=${{ inputs.namespace }}' \
+        '--driver-opt=loadbalance=sticky' \
+        '--driver-opt=replicas=${{ inputs.replicas }}' \
+        '--driver-opt=requests.cpu=${{ inputs.requests_cpu }}' \
+        '--driver-opt=requests.memory=${{ inputs.requests_memory }}' \
+        '--driver-opt=limits.memory=${{ inputs.limits_memory }}' \
+        '--driver-opt="nodeselector=kubernetes.io/arch=arm64,role=dynamo-builder-fallback"' \
+        '--driver-opt="tolerations=${{ inputs.tolerations }}"'
+
+        sleep 3 # Give the builders some time to be ready
+
+        if [[ "${{ inputs.suppress_fallback_warning }}" != "true" ]]; then
+          echo "::warning::Build is using fallback pod"
+          echo "## ⚠️ Fallback Build Warning" >> $GITHUB_STEP_SUMMARY
+          echo "This build is using the **fallback pod** because the preferred remote builders are unavailable. Expected during nightly runs and outside business hours." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+        fi
+
+
+
+    - name: Bootstrap buildkit
+      if: inputs.skip_bootstrap != 'true'
+      shell: bash
+      run: |
+        BUILDER_NAME="${BUILDX_BUILDER_NAME:-${{ inputs.builder_name }}}"
+        echo "Bootstrapping buildkit..."
+        for i in 1 2 3; do
+          if docker buildx inspect "$BUILDER_NAME" --bootstrap; then
+            echo "Bootstrap succeeded on attempt $i"
+            break
+          fi
+          if [ "$i" -eq 3 ]; then
+            echo "::error::Bootstrap failed after 3 attempts"
+            exit 1
+          fi
+          echo "::warning::Bootstrap attempt $i failed, retrying in 10s..."
+          sleep 10
+        done

--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -1,0 +1,370 @@
+name: 'Docker Build'
+description: 'Build Dynamo container images'
+inputs:
+  framework:
+    description: 'Framework to build'
+    required: true
+    default: 'vllm'
+  target:
+    description: 'Target to build'
+    required: false
+    default: 'runtime'
+  platform:
+    description: 'Docker platform to build on, ie. linux/amd64'
+    required: false
+    default: 'linux/amd64'
+  device:
+    description: 'Build device (cuda, xpu, cpu) used for cache key suffix'
+    required: false
+    default: 'cuda'
+  cuda_version:
+    description: 'CUDA version to use'
+    required: true
+  image_tag:
+    description: 'Custom image tag'
+    required: true
+  aws_default_region:
+    description: 'AWS Default Region'
+    required: false
+  sccache_s3_bucket:
+    description: 'SCCache S3 Bucket'
+    required: false
+  aws_account_id:
+    description: 'AWS Account ID'
+    required: false
+  no_cache:
+    description: 'Disable Docker build cache'
+    required: false
+  extra_tags:
+    description: 'Additional image tags (newline-separated list of full image:tag references)'
+    required: false
+    default: ''
+  push_image:
+    description: 'Push the image to the registry'
+    required: false
+    default: 'false'
+  no_load:
+    description: 'Do not load the image into docker (useful for validation-only builds)'
+    required: false
+    default: 'true'
+  use_sccache:
+    description: 'Use SCCache for caching'
+    required: false
+    default: 'true'
+  extra_build_args:
+    description: 'Additional Docker build args (newline-separated list of KEY=VALUE pairs)'
+    required: false
+    default: ''
+outputs:
+  image_tag:
+    description: 'Image Tag'
+    value: ${{ steps.build.outputs.image_tag }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build image
+      id: build
+      shell: bash
+      env:
+        AWS_DEFAULT_REGION: ${{ inputs.aws_default_region }}
+        SCCACHE_S3_BUCKET:  ${{ inputs.sccache_s3_bucket }}
+        PLATFORM: ${{ inputs.platform }}
+        ECR_HOSTNAME: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_JOB: ${{ github.job }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        DEVICE: ${{ inputs.device }}
+        CUDA_VERSION: ${{ inputs.cuda_version }}
+      run: |
+        set -x
+
+        IMAGE_TAG="${{ inputs.image_tag }}"
+
+        # Normalize platform: prepend linux/ only when not already present
+        PLATFORM_FLAG="${PLATFORM}"
+        if [[ "$PLATFORM_FLAG" != linux/* ]]; then
+          PLATFORM_FLAG="linux/${PLATFORM_FLAG}"
+        fi
+        # Sanitized platform for registry tags and filenames (no slashes or commas)
+        PLATFORM_SAFE=$(echo "${PLATFORM}" | sed 's|linux/||g; s/,/-/g')
+
+        CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*}
+        if [[ "${{ inputs.target }}" == "frontend" ]]; then
+          CACHE_TAG_SUFFIX=""
+        elif [[ "${DEVICE}" == "cuda" ]]; then
+          CACHE_TAG_SUFFIX="-cuda${CUDA_VERSION_MAJOR}"
+        else
+          CACHE_TAG_SUFFIX="-${DEVICE}"
+        fi
+
+        BUILD_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        echo "BUILD_START_TIME=${BUILD_START_TIME}" >> $GITHUB_ENV
+
+        echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+        # Create build logs directory
+        mkdir -p build-logs
+        BUILD_LOG_FILE="build-logs/build-${{ inputs.framework }}-${PLATFORM_SAFE}.log"
+        echo "BUILD_LOG_FILE=${BUILD_LOG_FILE}" >> $GITHUB_ENV
+        echo "📝 Build log will be saved to: ${BUILD_LOG_FILE}"
+
+        # Collect optional overrides provided by the workflow
+        # Set base cache args and set --cache-to if this is a main commit
+        CACHE_ARGS=""
+        if [[ "${{ inputs.target }}" != "frontend" ]]; then
+          CACHE_TAG="${{ inputs.framework }}${CACHE_TAG_SUFFIX}-${PLATFORM_SAFE}-cache"
+          CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG} "
+          CACHE_ARGS+="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG} "
+          if [[ "$GITHUB_REF_NAME" =~ ^release ]]; then
+            # Release branches also use release cache
+            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG},mode=max "
+          elif [[ "$GITHUB_REF_NAME" == "main" ]]; then
+            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max "
+          fi
+        else
+          CACHE_TAG="${{ inputs.target }}${CACHE_TAG_SUFFIX}-${PLATFORM_SAFE}-cache"
+          CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG} "
+          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max "
+          fi
+        fi
+
+        echo "$CACHE_ARGS"
+        # Collect optional overrides provided by the workflow
+        if [ "${{ inputs.no_cache }}" == "true" ]; then
+          EXTRA_ARGS+=" --no-cache"
+        fi
+        if [ "${{ inputs.use_sccache }}" == "true" ]; then
+          EXTRA_ARGS+=" --build-arg USE_SCCACHE=true"
+          EXTRA_ARGS+=" --build-arg SCCACHE_BUCKET=${SCCACHE_S3_BUCKET}"
+          EXTRA_ARGS+=" --build-arg SCCACHE_REGION=${AWS_DEFAULT_REGION}"
+        fi
+        if [ "${{ inputs.push_image }}" == "true" ]; then
+          EXTRA_ARGS+=" --push"
+        elif [ "${{ inputs.no_load }}" == "false" ]; then
+          EXTRA_ARGS+=" --load"
+        fi
+
+        # Add extra tags (each as a separate --tag argument)
+        EXTRA_TAGS="${{ inputs.extra_tags }}"
+        if [ -n "$EXTRA_TAGS" ]; then
+          while IFS= read -r EXTRA_TAG; do
+            if [ -n "$EXTRA_TAG" ]; then
+              EXTRA_ARGS+=" --tag ${EXTRA_TAG}"
+            fi
+          done <<< "$EXTRA_TAGS"
+        fi
+
+        # Add extra build args (each as a separate --build-arg)
+        EXTRA_BUILD_ARGS="${{ inputs.extra_build_args }}"
+        if [ -n "$EXTRA_BUILD_ARGS" ]; then
+          while IFS= read -r BUILD_ARG; do
+            if [ -n "$BUILD_ARG" ]; then
+              EXTRA_ARGS+=" --build-arg ${BUILD_ARG}"
+            fi
+          done <<< "$EXTRA_BUILD_ARGS"
+        fi
+
+        # Pass IRSA web identity token as build secrets for sccache S3 access.
+        # The runner pod has IRSA which provides AWS_WEB_IDENTITY_TOKEN_FILE and
+        # AWS_ROLE_ARN. We pass the token file and role ARN to BuildKit so sccache
+        # can authenticate via STS AssumeRoleWithWebIdentity -- no static keys needed.
+        SECRET_ARGS=""
+        if [ "${{ inputs.use_sccache }}" == "true" ]; then
+          TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
+          if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
+            SECRET_ARGS+=" --secret id=aws-web-identity-token,src=${TOKEN_FILE}"
+            SECRET_ARGS+=" --secret id=aws-role-arn,env=AWS_ROLE_ARN"
+          else
+            echo "::warning::IRSA web identity token not available; sccache S3 cache will be disabled"
+          fi
+        fi
+
+        docker buildx build \
+          --progress=plain \
+          --builder "${BUILDX_BUILDER_NAME:-default}" \
+          --tag "$IMAGE_TAG" \
+          --platform "${PLATFORM_FLAG}" \
+          -f ./container/rendered.Dockerfile \
+          $CACHE_ARGS $EXTRA_ARGS $SECRET_ARGS . 2>&1 | tee "${BUILD_LOG_FILE}"
+
+        BUILD_EXIT_CODE=${PIPESTATUS[0]}
+
+        BUILD_END_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        echo "BUILD_END_TIME=${BUILD_END_TIME}" >> $GITHUB_ENV
+
+        # Exit with the build's exit code
+        exit ${BUILD_EXIT_CODE}
+
+
+    - name: Capture Build Metrics
+      id: metrics
+      shell: bash
+      env:
+        AWS_DEFAULT_REGION: ${{ inputs.aws_default_region }}
+      run: |
+
+        # Create metrics directory
+        mkdir -p build-metrics
+
+        # Get accurate build timing
+        BUILD_START_TIME="${{ env.BUILD_START_TIME }}"
+        BUILD_END_TIME="${{ env.BUILD_END_TIME }}"
+
+        # Calculate duration
+        START_EPOCH=$(date -d "$BUILD_START_TIME" +%s)
+        END_EPOCH=$(date -d "$BUILD_END_TIME" +%s)
+        BUILD_DURATION_SEC=$((END_EPOCH - START_EPOCH))
+
+        echo "🕐 Build timing:"
+        echo "  Start: ${BUILD_START_TIME}"
+        echo "  End: ${BUILD_END_TIME}"
+        echo "  Duration: ${BUILD_DURATION_SEC} seconds"
+
+        # Get image size
+        IMAGE_TAG="${{ steps.build.outputs.image_tag }}"
+        IMAGE_SIZE_TYPE="unknown"
+        if [ -n "$IMAGE_TAG" ]; then
+          if [ "${{ inputs.no_load }}" == "false" ]; then
+            # Image was loaded into local Docker daemon but not pushed; docker inspect
+            # reports uncompressed (virtual) size, which differs from the compressed
+            # registry size reported below
+            IMAGE_SIZE_BYTES=$(docker image inspect "$IMAGE_TAG" --format='{{.Size}}' 2>/dev/null || echo "0")
+            IMAGE_SIZE_TYPE="uncompressed"
+          elif [ "${{ inputs.push_image }}" == "true" ]; then
+            # Image was pushed to ECR without loading locally; query ECR for compressed size
+            REPO_NAME=$(echo "$IMAGE_TAG" | sed 's|.*amazonaws.com/||' | cut -d: -f1)
+            IMAGE_TAG_NAME=$(echo "$IMAGE_TAG" | cut -d: -f2-)
+            IMAGE_SIZE_BYTES=$(aws ecr describe-images \
+              --repository-name "$REPO_NAME" \
+              --image-ids "imageTag=${IMAGE_TAG_NAME}" \
+              --query 'imageDetails[0].imageSizeInBytes' \
+              --output text 2>/dev/null || echo "0")
+            # Treat empty or "None" response as 0
+            if [[ "$IMAGE_SIZE_BYTES" == "None" || -z "$IMAGE_SIZE_BYTES" ]]; then
+              IMAGE_SIZE_BYTES=0
+            fi
+            IMAGE_SIZE_TYPE="compressed"
+          else
+            IMAGE_SIZE_BYTES=0
+          fi
+          echo "📦 Image size: ${IMAGE_SIZE_BYTES} bytes (${IMAGE_SIZE_TYPE})"
+        else
+          IMAGE_SIZE_BYTES=0
+          echo "⚠️  No image tag available"
+        fi
+
+        PLATFORM_ARCH=$(echo "${{ inputs.platform }}" | sed 's|linux/||g; s/,/-/g')
+        echo "  Architecture: ${PLATFORM_ARCH}"
+        echo "PLATFORM_ARCH=${PLATFORM_ARCH}" >> $GITHUB_ENV
+        JOB_KEY="${{ inputs.framework }}-${PLATFORM_ARCH}"
+        echo "  Job Key: ${JOB_KEY}"
+
+        # Create job-specific metrics file
+        mkdir -p build-metrics
+        METRICS_FILE="build-metrics/metrics-${{ inputs.framework }}-${PLATFORM_ARCH}-${{ github.run_id }}-${{ job.check_run_id }}.json"
+
+        # Create the job metrics file
+        cat > "$METRICS_FILE" << EOF
+        {
+          "framework": "${{ inputs.framework }}",
+          "target": "${{ inputs.target }}",
+          "platform": "${{ inputs.platform }}",
+          "platform_arch": "${PLATFORM_ARCH}",
+          "image_size_bytes": ${IMAGE_SIZE_BYTES},
+          "image_size_type": "${IMAGE_SIZE_TYPE}",
+          "build_start_time": "${BUILD_START_TIME}",
+          "build_end_time": "${BUILD_END_TIME}",
+          "build_duration_sec": ${BUILD_DURATION_SEC}
+        }
+        EOF
+
+        cat "$METRICS_FILE"
+
+    - name: Generate Comprehensive Build Metrics
+      id: comprehensive-metrics
+      if: always()
+      shell: bash
+      run: |
+        echo "=========================================="
+        echo "📊 GENERATING COMPREHENSIVE BUILD METRICS"
+        echo "=========================================="
+
+        # Create metrics directory
+        mkdir -p build-metrics
+
+        PLATFORM_ARCH="${{ env.PLATFORM_ARCH }}"
+        WORKFLOW_ID="${{ github.run_id }}"
+        JOB_ID="${{ job.check_run_id }}"
+        FRAMEWORK_LOWER=$(echo "${{ inputs.framework }}" | tr '[:upper:]' '[:lower:]')
+
+        # Make parser executable
+        chmod +x .github/scripts/parse_buildkit_output.py
+
+        # Check for build logs and build stage arguments dynamically
+        # Use the BUILD_LOG_FILE set during the build step
+        BUILD_LOG="${{ env.BUILD_LOG_FILE }}"
+
+        # Path to container metadata created in previous step
+        CONTAINER_METADATA="build-metrics/metrics-${{ inputs.framework }}-${PLATFORM_ARCH}-${WORKFLOW_ID}-${JOB_ID}.json"
+
+        # Output single comprehensive JSON with all build stages
+        COMPREHENSIVE_JSON="build-metrics/build-${{ inputs.framework }}-${PLATFORM_ARCH}-${WORKFLOW_ID}-${JOB_ID}.json"
+
+        echo "🚀 Parsing BuildKit outputs and merging with container metrics..."
+
+        # Build stage arguments dynamically based on which logs exist
+        STAGE_ARGS=()
+
+        if [ -f "$BUILD_LOG" ]; then
+          echo "  ✓ Found base image log: ${BUILD_LOG}"
+          STAGE_ARGS+=("runtime:${BUILD_LOG}")
+        else
+          echo "  ℹ️  No image log found"
+        fi
+
+        # Check for any additional stage logs (e.g., build-logs/stage3-*.log)
+        for extra_log in build-logs/stage*.log; do
+          if [ -f "$extra_log" ]; then
+            stage_name=$(basename "$extra_log" .log)
+            echo "  ✓ Found additional stage log: ${extra_log} (${stage_name})"
+            STAGE_ARGS+=("${stage_name}:${extra_log}")
+          fi
+        done
+
+        echo "Container Metadata: ${CONTAINER_METADATA}"
+        echo "Output: ${COMPREHENSIVE_JSON}"
+        echo ""
+
+        # Run parser with all discovered stages
+        # Usage: parse_buildkit_output.py <output_json> <stage1_name:log_file> [stage2_name:log_file] ... [--metadata=<file>]
+        set +e
+        python3 .github/scripts/parse_buildkit_output.py \
+          "$COMPREHENSIVE_JSON" \
+          "${STAGE_ARGS[@]}" \
+          "--metadata=${CONTAINER_METADATA}"
+        PARSER_EXIT_CODE=$?
+        set -e
+
+        echo ""
+        echo "📊 Parser exit code: ${PARSER_EXIT_CODE}"
+
+        if [ ${PARSER_EXIT_CODE} -eq 0 ] && [ -f "$COMPREHENSIVE_JSON" ]; then
+          echo "✅ Comprehensive build metrics generated successfully"
+          echo "📄 Output file: ${COMPREHENSIVE_JSON}"
+        else
+          echo "⚠️  Metrics generation had issues but continuing..."
+        fi
+
+    # Upload comprehensive build metrics as artifact
+    - name: Upload Comprehensive Build Metrics
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
+      if: always()
+      continue-on-error: true
+      with:
+        name: build-metrics-${{ inputs.framework }}-${{ inputs.target }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: build-metrics/build-${{ inputs.framework }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}.json
+        retention-days: 7
+        compression-level: 0
+

--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -268,6 +268,7 @@ runs:
     - name: Generate Comprehensive Build Metrics
       id: comprehensive-metrics
       if: always()
+      continue-on-error: true
       shell: bash
       run: |
         echo "=========================================="

--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -110,25 +110,8 @@ runs:
         echo "📝 Build log will be saved to: ${BUILD_LOG_FILE}"
 
         # Collect optional overrides provided by the workflow
-        # Set base cache args and set --cache-to if this is a main commit
+        # Remote cache disabled (no ECR configured)
         CACHE_ARGS=""
-        if [[ "${{ inputs.target }}" != "frontend" ]]; then
-          CACHE_TAG="${{ inputs.framework }}${CACHE_TAG_SUFFIX}-${PLATFORM_SAFE}-cache"
-          CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG} "
-          CACHE_ARGS+="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG} "
-          if [[ "$GITHUB_REF_NAME" =~ ^release ]]; then
-            # Release branches also use release cache
-            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG},mode=max "
-          elif [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max "
-          fi
-        else
-          CACHE_TAG="${{ inputs.target }}${CACHE_TAG_SUFFIX}-${PLATFORM_SAFE}-cache"
-          CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG} "
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max "
-          fi
-        fi
 
         echo "$CACHE_ARGS"
         # Collect optional overrides provided by the workflow

--- a/.github/actions/init-dynamo-builder/action.yml
+++ b/.github/actions/init-dynamo-builder/action.yml
@@ -1,0 +1,165 @@
+name: 'Initialize Dynamo Builder'
+description: 'Route buildkit workers and bootstrap buildx builder for dynamo builds'
+
+# This action combines buildkit worker discovery and builder bootstrapping into a single step.
+# It wraps route_buildkit.sh and bootstrap-buildkit action to simplify workflow configuration.
+#
+# How it works:
+#   1. Discovers available BuildKit pods via Kubernetes DNS using route_buildkit.sh
+#   2. Routes pods to the specified flavor based on modulo-3 strategy (see route_buildkit.sh)
+#   3. Bootstraps a docker buildx builder using the discovered workers
+#   4. Falls back to Kubernetes driver if no remote workers are available
+#
+# Architecture modes:
+#   - Single arch: Set arch to 'linux/amd64' or 'linux/arm64'
+#   - Multi arch:  Set arch to 'linux/amd64,linux/arm64'
+#
+# Flavor routing:
+#   BuildKit pods are assigned to flavors based on pod index modulo 3:
+#   - Pool 0 (mod 0): vllm-cuda12, trtllm-cuda12
+#   - Pool 1 (mod 1): vllm-cuda13, trtllm-cuda13, sglang-cuda13
+#   - Pool 2 (mod 2): sglang-cuda12, general (any/no CUDA)
+#
+# Usage examples:
+#   # Initialize for both architectures with general flavor:
+#   - uses: ./.github/actions/init-dynamo-builder
+#     with:
+#       builder_name: my-builder
+#       flavor: general
+#       arch: 'linux/amd64,linux/arm64'
+#
+#   # Initialize for single architecture with specific flavor and CUDA version:
+#   - uses: ./.github/actions/init-dynamo-builder
+#     with:
+#       builder_name: my-builder
+#       flavor: vllm
+#       arch: 'linux/amd64'
+#       cuda_version: '12.9'
+
+inputs:
+  builder_name:
+    description: 'Name for the buildx builder'
+    required: true
+  flavor:
+    description: 'Buildkit flavor (vllm, trtllm, sglang, general)'
+    required: false
+    default: 'general'
+  arch:
+    description: 'Docker platform string: linux/amd64, linux/arm64, or linux/amd64,linux/arm64'
+    required: false
+    default: 'linux/amd64'
+  cuda_version:
+    description: 'CUDA version (12.9, 13.0). Optional for general flavor.'
+    required: false
+    default: ''
+  fresh_builder:
+    description: 'Skip remote worker routing and always use the K8s driver. Set by callers that want a fresh, isolated builder per run.'
+    required: false
+    default: 'false'
+
+  # Passthrough inputs for bootstrap-buildkit (kubernetes fallback)
+  ephemeral_storage:
+    description: 'Ephemeral storage request for Kubernetes driver'
+    required: false
+    default: '400Gi'
+  namespace:
+    description: 'Kubernetes namespace for buildkit pods'
+    required: false
+    default: 'buildkit'
+  replicas:
+    description: 'Number of buildkit replicas'
+    required: false
+    default: '1'
+  requests_cpu:
+    description: 'CPU requests for buildkit pods'
+    required: false
+    default: '12'
+  requests_memory:
+    description: 'Memory requests for buildkit pods'
+    required: false
+    default: '26Gi'
+  limits_memory:
+    description: 'Memory limits for buildkit pods'
+    required: false
+    default: '29Gi'
+  tolerations:
+    description: 'Tolerations for buildkit pods'
+    required: false
+    default: "key=buildkit-fallback-worker,value=true,operator=Equal,effect=NoSchedule"
+  use_runner_docker_builder:
+    description: 'When true and no remote workers are configured, skip Kubernetes builder creation and reuse the runner docker builder.'
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Route buildkit workers
+      id: route-buildkit
+      if: inputs.use_runner_docker_builder != 'true' && inputs.fresh_builder != 'true'
+      continue-on-error: true
+      shell: bash
+      run: |
+        CUDA_ARG=""
+        if [[ -n "${{ inputs.cuda_version }}" ]]; then
+          CUDA_ARG="--cuda ${{ inputs.cuda_version }}"
+        fi
+        # Strip linux/ prefix (e.g. linux/amd64,linux/arm64 → amd64,arm64)
+        ARCH="${{ inputs.arch }}"
+        ARCH="${ARCH//linux\//}"
+        if [[ "$ARCH" == *","* ]]; then
+          ROUTE_ARCH="all"
+        else
+          ROUTE_ARCH="$ARCH"
+        fi
+        echo "running with --arch ${ROUTE_ARCH} --flavor ${{ inputs.flavor }} $CUDA_ARG"
+        .github/scripts/route_buildkit.sh --arch ${ROUTE_ARCH} --flavor ${{ inputs.flavor }} $CUDA_ARG
+
+    - name: Prepare worker addresses and platform
+      id: prepare
+      if: inputs.fresh_builder != 'true'
+      shell: bash
+      env:
+        AMD64_ADDRS: ${{ steps.route-buildkit.outputs[format('{0}_amd64', inputs.flavor)] }}
+        ARM64_ADDRS: ${{ steps.route-buildkit.outputs[format('{0}_arm64', inputs.flavor)] }}
+      run: |
+        if [[ "${{ inputs.use_runner_docker_builder }}" == "true" ]]; then
+          echo "Skipping remote BuildKit discovery; forcing local Kubernetes builder fallback."
+          echo "worker_addresses=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        # Strip linux/ prefix (e.g. linux/amd64,linux/arm64 → amd64,arm64)
+        ARCH="${{ inputs.arch }}"
+        ARCH="${ARCH//linux\//}"
+        if [[ "$ARCH" == *","* ]]; then
+          # Multi-arch: combine both worker pools
+          if [[ -n "$AMD64_ADDRS" && -n "$ARM64_ADDRS" ]]; then
+            echo "worker_addresses=${AMD64_ADDRS},${ARM64_ADDRS}" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$AMD64_ADDRS" ]]; then
+            echo "worker_addresses=${AMD64_ADDRS}" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$ARM64_ADDRS" ]]; then
+            echo "worker_addresses=${ARM64_ADDRS}" >> "$GITHUB_OUTPUT"
+          else
+            echo "worker_addresses=" >> "$GITHUB_OUTPUT"
+          fi
+        elif [[ "$ARCH" == "arm64" ]]; then
+          echo "worker_addresses=${ARM64_ADDRS}" >> "$GITHUB_OUTPUT"
+        else
+          echo "worker_addresses=${AMD64_ADDRS}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Bootstrap buildkit
+      uses: ./.github/actions/bootstrap-buildkit
+      with:
+        builder_name: ${{ inputs.builder_name }}
+        buildkit_worker_addresses: ${{ steps.prepare.outputs.worker_addresses }}
+        fresh_builder: ${{ inputs.fresh_builder }}
+        ephemeral_storage: ${{ inputs.ephemeral_storage }}
+        namespace: ${{ inputs.namespace }}
+        replicas: ${{ inputs.replicas }}
+        requests_cpu: ${{ inputs.requests_cpu }}
+        requests_memory: ${{ inputs.requests_memory }}
+        limits_memory: ${{ inputs.limits_memory }}
+        tolerations: ${{ inputs.tolerations }}
+        use_runner_docker_builder: ${{ inputs.use_runner_docker_builder }}
+

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -1,0 +1,443 @@
+﻿name: 'Pytest'
+description: 'Run pytest on pre-built container images'
+inputs:
+  pytest_marks:
+    description: 'Pytest marks'
+    required: true
+    default: 'e2e and vllm and gpu_1 and not slow'
+  image_tag:
+    description: 'Image Tag to run tests on'
+    required: true
+  test_suite_name:
+    description: 'Framework name for test metrics'
+    required: false
+    default: 'unknown'
+  test_type:
+    description: 'Test type (unit, e2e, integration)'
+    required: false
+    default: 'e2e'
+  platform_arch:
+    description: 'Platform architecture (amd64, arm64)'
+    required: false
+    default: 'amd64'
+  dry_run:
+    description: 'Run pytest in dry-run mode (collect tests only, do not execute)'
+    required: false
+    default: 'false'
+  start_minio:
+    description: 'Start MinIO service for LoRA tests (true/false)'
+    required: false
+    default: 'true'
+  hf_token:
+    required: false
+  parallel_mode:
+    description: 'Parallelization mode: auto (use all cores), none/0 (sequential), or a number of workers'
+    required: false
+    default: 'auto'
+  dind_as_sidecar:
+    description: 'dind runs as a sidecar container (true/false)'
+    required: false
+    default: 'false'
+  cpu_limit:
+    description: 'Maximum number of cores available to docker'
+    required: false
+    default: '10'
+  device:
+    description: 'Target device (cuda, xpu, cpu)'
+    required: false
+    default: 'cuda'
+  enable_coverage:
+    description: 'Enable coverage collection (true/false)'
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Test Environment
+      shell: bash
+      run: |
+        # Setup test directories
+        mkdir -p test-results
+
+        # Set platform architecture from input
+        PLATFORM_ARCH="${{ inputs.platform_arch }}"
+        if [[ -z "${PLATFORM_ARCH}" ]]; then
+          PLATFORM_ARCH="amd64"
+        fi
+        echo "PLATFORM_ARCH=${PLATFORM_ARCH}" >> $GITHUB_ENV
+        echo "🏗️  Platform architecture: ${PLATFORM_ARCH}"
+
+    - name: Start MinIO Service
+      if: inputs.start_minio == 'true'
+      shell: bash
+      env:
+        MINIO_CONTAINER_NAME: dynamo-minio-test
+        MINIO_ACCESS_KEY: minioadmin
+        MINIO_SECRET_KEY: minioadmin
+      run: |
+        # Start MinIO for S3-compatible object storage (used by LoRA tests)
+        echo "🗄️  Starting MinIO service..."
+
+        # Check container state
+        CONTAINER_STATE=$(docker inspect --format '{{.State.Status}}' "${MINIO_CONTAINER_NAME}" 2>/dev/null || echo "absent")
+
+        if [[ "${CONTAINER_STATE}" == "running" ]]; then
+          echo "✅ MinIO container is already running, skipping start"
+          exit 0
+        elif [[ "${CONTAINER_STATE}" == "exited" || "${CONTAINER_STATE}" == "created" || "${CONTAINER_STATE}" == "paused" ]]; then
+          echo "▶️  MinIO container exists but is stopped (${CONTAINER_STATE}), starting it..."
+          docker start "${MINIO_CONTAINER_NAME}"
+        else
+          echo "🆕 No MinIO container found, creating a new one..."
+          docker run -d \
+            --name "${MINIO_CONTAINER_NAME}" \
+            -p 9000:9000 \
+            -p 9001:9001 \
+            -e "MINIO_ROOT_USER=${MINIO_ACCESS_KEY}" \
+            -e "MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}" \
+            quay.io/minio/minio server /data --console-address ':9001'
+        fi
+
+        # Wait for MinIO to be ready
+        echo "⏳ Waiting for MinIO to be ready..."
+        MAX_ATTEMPTS=30
+        ATTEMPT=0
+        while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+          if curl -sf http://localhost:9000/minio/health/live > /dev/null 2>&1; then
+            echo "✅ MinIO is ready (attempt $((ATTEMPT + 1)))"
+            break
+          fi
+          ATTEMPT=$((ATTEMPT + 1))
+          if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+            echo "❌ MinIO failed to start within ${MAX_ATTEMPTS}s"
+            echo "📋 Container logs:"
+            docker logs "${MINIO_CONTAINER_NAME}" 2>&1 || true
+            exit 1
+          fi
+          sleep 1
+        done
+
+    - name: Run tests for runner v1
+      if: inputs.dind_as_sidecar == 'false'
+      shell: bash
+      env:
+        NUM_CPUS: ${{ inputs.cpu_limit }}
+        CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
+        PYTEST_XML_FILE: pytest_test_report.xml
+        HF_HOME: /runner/_work/_temp
+        HF_TOKEN: ${{ inputs.hf_token }}
+      run: |
+        # Run pytest with detailed output and JUnit XML
+        set +e  # Don't exit on test failures
+
+        # Determine docker runtime flags and pytest command based on dry_run mode
+        if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+          echo "🔍 Running pytest in dry-run mode (collect-only, no GPU required)"
+          GPU_FLAGS=""
+          PYTEST_CMD="pytest -v --collect-only -m \"${{ inputs.pytest_marks }}\""
+        else
+          echo "🚀 Running pytest in normal mode"
+          # --durations=0: show ALL test/setup/teardown durations (0 = no limit)
+          PYTEST_CMD="pytest --continue-on-collection-errors -v --tb=short --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=0 -m \"${{ inputs.pytest_marks }}\""
+
+          # Add coverage flags if enabled
+          COVERAGE_FLAGS=""
+          COVERAGE_ENV=""
+          if [[ "${{ inputs.enable_coverage }}" == "true" ]]; then
+            echo "📊 Coverage collection enabled"
+            COVERAGE_FLAGS="--cov=components/src/dynamo --cov=lib/bindings/python/src/dynamo --cov-report="
+            COVERAGE_ENV="--env COVERAGE_FILE=/workspace/test-results/.coverage --env PYTHONPATH=/workspace/components/src:/workspace/lib/bindings/python/src"
+            PYTEST_CMD="${PYTEST_CMD} ${COVERAGE_FLAGS}"
+          fi
+
+          # Set device-specific docker flags
+          GPU_FLAGS=""
+          DOCKER_EXTRA_FLAGS=()
+          if [[ "${{ inputs.device }}" == "xpu" ]]; then
+            echo "✓ XPU device specified, enabling /dev/dri device flags"
+            RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)
+            GPU_FLAGS="--device /dev/dri:/dev/dri --group-add ${RENDER_GID}"
+            DOCKER_EXTRA_FLAGS=(--privileged  -v "/dev/dri:/dev/dri")
+            # Model predownload on XPU can exceed default pytest-timeout in CI.
+            PYTEST_CMD="${PYTEST_CMD} --timeout=600"
+          elif command -v nvidia-smi &> /dev/null && nvidia-smi &> /dev/null; then
+            echo "✓ GPU detected, enabling GPU runtime"
+            GPU_FLAGS="--runtime=nvidia --gpus all"
+          else
+            echo "⚠️  No GPU detected, running in CPU-only mode"
+          fi
+        fi
+
+        # Get absolute path for test-results directory and ensure it has proper permissions
+        TEST_RESULTS_DIR="$(pwd)/test-results"
+        chmod 777 "${TEST_RESULTS_DIR}"
+        echo "📁 Test results will be saved to: ${TEST_RESULTS_DIR}"
+
+        DOCKER_ENV_FLAGS=()
+        if [[ -n "${HF_TOKEN:-}" ]]; then
+          DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
+        fi
+        DOCKER_ENV_FLAGS+=(--env "VLLM_LOGGING_LEVEL=DEBUG")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.test_suite_name }}")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_TYPE=${{ inputs.test_type }}")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_WORKFLOW=${GITHUB_WORKFLOW}")
+
+        echo "🐳 Docker run command (runner v1):"
+        echo "docker run ${GPU_FLAGS} ${DOCKER_EXTRA_FLAGS[@]} --rm -w /workspace --cpus=${NUM_CPUS} --network host ${DOCKER_ENV_FLAGS[@]} --name ${{ env.CONTAINER_ID }}_pytest -v ${TEST_RESULTS_DIR}:/workspace/test-results ${{ inputs.image_tag }} bash -c \"${PYTEST_CMD}\""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        # Pre-cleanup: remove any leftover containers with the same name
+        echo "🧹 Removing any leftover containers with name ${{ env.CONTAINER_ID }}_pytest..."
+        docker rm -f "${{ env.CONTAINER_ID }}_pytest" 2>/dev/null || true
+
+        docker run ${GPU_FLAGS} \
+          "${DOCKER_EXTRA_FLAGS[@]}" \
+          --rm -w /workspace \
+          --cpus=${NUM_CPUS} \
+          --shm-size=200m \
+          --network host \
+          --memory=6g \
+          "${DOCKER_ENV_FLAGS[@]}" \
+          ${COVERAGE_ENV} \
+          --name ${{ env.CONTAINER_ID }}_pytest \
+          -v "${TEST_RESULTS_DIR}:/workspace/test-results" \
+          ${{ inputs.image_tag }} \
+          sh -c "umask 0022 && ${PYTEST_CMD}"
+
+        TEST_EXIT_CODE=$?
+        echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
+        echo "🧪 Tests completed with exit code: ${TEST_EXIT_CODE}"
+
+        # Verify test results were written (only in normal mode)
+        if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+          if [[ -f "${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}" ]]; then
+            echo "✅ Test results file found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
+          else
+            echo "⚠️  Test results file not found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
+          fi
+        fi
+
+        # Always continue to results processing
+        exit 0
+
+    - name: Run tests in dind as sidecar mode
+      if: inputs.dind_as_sidecar == 'true'
+      shell: bash
+      env:
+        CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
+        PYTEST_XML_FILE: pytest_test_report.xml
+        HF_HOME: /runner/_work/_temp
+        HF_TOKEN: ${{ inputs.hf_token }}
+      run: |
+        # Run pytest with detailed output and JUnit XML
+        set +e  # Don't exit on test failures
+
+        # /dev/shm sizing: NIXL uses UCX which allocates shared memory segments in /dev/shm
+        # via shm_open(). Each NIXL agent with num_threads=8 creates 9 UCX workers, each needing
+        # ~4.8MB of shm. Disaggregated tests use up to 3 agents (encode+prefill+decode) = ~130MB.
+        # Docker's default is 64MB, which is insufficient and causes segfaults.
+        # Do NOT use --ipc=host here — it overrides --shm-size with the host's /dev/shm
+        # (64MB in K8s pods by default), silently ignoring the size we set.
+        DOCKER_OPTS="--shm-size=200m --ulimit memlock=-1 --ulimit stack=67108864"
+
+        # Determine docker runtime flags and pytest command based on dry_run mode
+        if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+          echo "🔍 Running pytest in dry-run mode (collect-only, no GPU required)"
+          GPU_FLAGS=""
+          PYTEST_CMD="pytest -v --collect-only -m \"${{ inputs.pytest_marks }}\""
+        else
+          echo "🚀 Running pytest in normal mode"
+          # Set device-specific docker flags
+          GPU_FLAGS=""
+          DOCKER_EXTRA_FLAGS=()
+          if [[ "${{ inputs.device }}" == "xpu" ]]; then
+            echo "✓ XPU device specified, enabling /dev/dri device flags"
+            RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)
+            GPU_FLAGS="--device /dev/dri:/dev/dri --group-add ${RENDER_GID}"
+            DOCKER_EXTRA_FLAGS=(--privileged  -v "/dev/dri:/dev/dri" -e "ZE_AFFINITY_MASK=${ZE_AFFINITY_MASK:-}")
+            PYTEST_TIMEOUT_OPT="--timeout=600"
+          elif docker info 2>/dev/null | grep -i "runtimes" | grep -q "nvidia"; then
+            echo "✓ Docker Daemon supports Nvidia runtime, enabling GPU flags"
+            GPU_FLAGS="--gpus all"
+            PYTEST_TIMEOUT_OPT=""
+          else
+            echo "⚠️  No GPU detected, running in CPU-only mode"
+            PYTEST_TIMEOUT_OPT=""
+          fi
+
+          # Determine parallelization based on parallel_mode input
+          case "${{ inputs.parallel_mode }}" in
+            "auto")
+              PARALLEL_OPTS="-n auto"
+              echo "📊 Parallelization: auto (use all available cores)"
+              ;;
+            "none"|"0")
+              PARALLEL_OPTS="-n 0"
+              echo "📊 Parallelization: disabled (sequential execution) for GPU runs"
+              ;;
+            *)
+              PARALLEL_OPTS="-n ${{ inputs.parallel_mode }}"
+              echo "📊 Parallelization: ${{ inputs.parallel_mode }} workers"
+              ;;
+          esac
+
+          # Construct final command with xdist parallelization (-n) and other options
+          # --dist=loadscope groups tests by module/class to prevent race conditions in stateful tests
+          # --durations=0: show ALL test/setup/teardown durations (0 = no limit)
+          PYTEST_CMD="pytest ${PARALLEL_OPTS} --dist=loadscope --continue-on-collection-errors -v --tb=short -s --log-cli-level=DEBUG --log-level=DEBUG --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=0 ${PYTEST_TIMEOUT_OPT} -m \"${{ inputs.pytest_marks }}\""
+
+          # Add coverage flags if enabled
+          COVERAGE_FLAGS=""
+          COVERAGE_ENV=""
+          if [[ "${{ inputs.enable_coverage }}" == "true" ]]; then
+            echo "📊 Coverage collection enabled"
+            COVERAGE_FLAGS="--cov=components/src/dynamo --cov=lib/bindings/python/src/dynamo --cov-report="
+            COVERAGE_ENV="--env COVERAGE_FILE=/workspace/test-results/.coverage --env PYTHONPATH=/workspace/components/src:/workspace/lib/bindings/python/src"
+            PYTEST_CMD="${PYTEST_CMD} ${COVERAGE_FLAGS}"
+          fi
+        fi
+
+        # Get absolute path for test-results directory and ensure it has proper permissions
+        TEST_RESULTS_DIR="$(pwd)/test-results"
+        chmod 777 "${TEST_RESULTS_DIR}"
+        echo "📁 Test results will be saved to: ${TEST_RESULTS_DIR}"
+        echo "▶️ Executing: $PYTEST_CMD"
+
+        DOCKER_ENV_FLAGS=()
+        if [[ -n "${HF_TOKEN:-}" ]]; then
+          DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
+        fi
+        DOCKER_ENV_FLAGS+=(--env "VLLM_LOGGING_LEVEL=DEBUG")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.test_suite_name }}")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_TYPE=${{ inputs.test_type }}")
+        DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_WORKFLOW=${GITHUB_WORKFLOW}")
+
+        echo "** Available local docker images (dynamo/vllm related):"
+        docker images --format '{{.Repository}}:{{.Tag}}\t{{.ID}}\t{{.Size}}' | grep -E 'dynamo|vllm|non_cuda|xpu' || echo '(none matching dynamo/vllm/xpu)'
+        echo "** Image to be used: ${{ inputs.image_tag }}"
+        docker inspect --format 'ID={{.Id}} Created={{.Created}} Size={{.Size}}' '${{ inputs.image_tag }}' 2>/dev/null || echo 'WARNING: Image not found locally: ${{ inputs.image_tag }}'
+        echo "** Docker run command (dind sidecar):"
+        echo "docker run ${GPU_FLAGS} ${DOCKER_OPTS} ${DOCKER_EXTRA_FLAGS[@]} --rm -w /workspace --network host ${DOCKER_ENV_FLAGS[@]} --name ${{ env.CONTAINER_ID }}_pytest -v ${TEST_RESULTS_DIR}:/workspace/test-results ${{ inputs.image_tag }} bash -c \"${PYTEST_CMD}\""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        # Pre-cleanup: remove any leftover containers with the same name
+        echo "🧹 Removing any leftover containers with name ${{ env.CONTAINER_ID }}_pytest..."
+        docker rm -f "${{ env.CONTAINER_ID }}_pytest" 2>/dev/null || true
+        docker run ${GPU_FLAGS} ${DOCKER_OPTS} \
+          "${DOCKER_EXTRA_FLAGS[@]}" \
+          --rm -w /workspace \
+          --network host \
+          "${DOCKER_ENV_FLAGS[@]}" \
+          ${COVERAGE_ENV} \
+          --name ${{ env.CONTAINER_ID }}_pytest \
+          -v "${TEST_RESULTS_DIR}:/workspace/test-results" \
+          ${{ inputs.image_tag }} \
+          sh -c "umask 0022 && ${PYTEST_CMD}"
+
+        TEST_EXIT_CODE=$?
+        echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
+        echo "🧪 Tests completed with exit code: ${TEST_EXIT_CODE}"
+
+        # Verify test results were written (only in normal mode)
+        if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+          if [[ -f "${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}" ]]; then
+            echo "✅ Test results file found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
+          else
+            echo "⚠️  Test results file not found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
+          fi
+        fi
+
+        # Always continue to results processing
+        exit 0
+
+    - name: Process Test Results
+      shell: bash
+      run: |
+        # Sanitize test_type for filenames (always set this for artifact upload)
+        # Remove commas and spaces from test_type for use in filenames
+        STR_TEST_TYPE=$(echo "${{ inputs.test_type }}" | tr ', ' '_')
+        echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
+
+        # Check for JUnit XML file and determine test status
+        JUNIT_FILE="test-results/pytest_test_report.xml"
+
+        if [[ -f "$JUNIT_FILE" ]]; then
+          echo "✅ JUnit XML generated successfully"
+          # Extract basic test counts for status determination
+          TOTAL_TESTS=$(grep -o 'tests="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
+          FAILED_TESTS=$(grep -o 'failures="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
+          ERROR_TESTS=$(grep -o 'errors="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
+          echo "📊 ${TOTAL_TESTS} tests completed (${FAILED_TESTS} failed, ${ERROR_TESTS} errors)"
+
+          # Rename XML file to unique name
+          JUNIT_NAME="pytest_test_report_${{ inputs.test_suite_name }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
+          mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
+          echo "📝 Renamed XML file to: $JUNIT_NAME"
+        else
+          echo "⚠️  JUnit XML file not found - test results may not be available for upload"
+          TOTAL_TESTS=0
+          FAILED_TESTS=1  # Treat missing XML as failure
+          ERROR_TESTS=0
+        fi
+
+        exit 0
+
+    #- name: Cleanup MinIO Service
+    #  if: always() && inputs.start_minio == 'true' && env.MINIO_STARTED_BY_ACTION == 'true'
+    #  shell: bash
+    #  run: |
+    #    echo "🧹 Cleaning up MinIO container..."
+    #    docker rm -f dynamo-minio-test 2>/dev/null || true
+
+    - name: Cleanup Pytest Containers
+      if: always() && inputs.device == 'xpu'
+      shell: bash
+      run: |
+        echo "🧹 Cleaning up pytest containers..."
+        # Clean up pytest containers that may be left over (especially from runner v1)
+        CONTAINER_ID_PREFIX="test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}"
+        PYTEST_CONTAINERS=$(docker ps -aq --filter "name=${CONTAINER_ID_PREFIX}" 2>/dev/null || true)
+        if [[ -n "${PYTEST_CONTAINERS}" ]]; then
+          echo "Found pytest containers: ${PYTEST_CONTAINERS}"
+          echo "Stopping and removing pytest containers..."
+          docker stop ${PYTEST_CONTAINERS} 2>/dev/null || true
+          docker rm -f ${PYTEST_CONTAINERS} 2>/dev/null || true
+          echo "✓ Pytest containers cleaned up"
+        else
+          echo "No pytest containers found"
+        fi
+
+    - name: Upload Test Results
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      if: always()  # Always upload test results, even if tests failed
+      with:
+        name: test-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: test-results/pytest_test_report_${{ inputs.test_suite_name }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
+        retention-days: 7
+
+    - name: Upload Allure Results
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      if: always()
+      with:
+        name: allure-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: test-results/allure-results/
+        retention-days: 7
+        if-no-files-found: ignore
+
+    - name: Upload Coverage Data
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      if: always() && inputs.enable_coverage == 'true'
+      with:
+        name: coverage-python-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: test-results/
+        include-hidden-files: true
+
+    - name: Report Test Exit Code
+      if: always()
+      shell: bash
+      run: |
+        # Propagate the original test exit code after cleanup and uploads
+        exit ${TEST_EXIT_CODE:-0}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -196,7 +196,7 @@ jobs:
       use_sccache: false
       push_image: false
       dynamo_repo: VincyZhang/dynamo
-      dynamo_ref: enbale_xpu_ci
+      dynamo_ref: enable_more_xpu_test
     secrets: inherit
 
   vllm-dev-build:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,673 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  # The group name is the ref_name, so that workflows on the same PR/branch have the same group name for cancelling.
+  group: docker-build-test-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  # ============================================================================
+  # SETUP & DETECTION JOBS
+  # ============================================================================
+  changed-files:
+    if: false
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.changes.outputs.core }}
+      planner: ${{ steps.changes.outputs.planner }}
+      operator: ${{ steps.changes.outputs.operator }}
+      deploy: ${{ steps.changes.outputs.deploy }}
+      vllm: ${{ steps.changes.outputs.vllm }}
+      sglang: ${{ steps.changes.outputs.sglang }}
+      trtllm: ${{ steps.changes.outputs.trtllm }}
+      builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          fetch-depth: 0
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/changed-files
+        with:
+          gh_token: ${{ github.token }}
+      - name: Export builder name
+        id: export-builder-name
+        run: |
+          echo "builder_name=${{ env.BUILDER_NAME }}" >> $GITHUB_OUTPUT
+
+  #  backend-status-check:
+  #    runs-on: ubuntu-latest
+  #    needs:
+  #      - changed-files
+  #      - operator
+  #      - vllm-build
+  #      - vllm-dev-build
+  #      - vllm-test
+  #      - vllm-multi-gpu-test
+  #      - vllm-copy-to-acr
+  #      - sglang-build
+  #      - sglang-dev-build
+  #      - sglang-test
+  #      - sglang-multi-gpu-test
+  #      - sglang-copy-to-acr
+  #      - trtllm-build
+  #      - trtllm-dev-build
+  #      - trtllm-test
+  #      - trtllm-multi-gpu-test
+  #      - trtllm-copy-to-acr
+  #      - planner-build
+  #      - planner-test
+  #    if: false
+  #    steps:
+  #      - name: Check all dependent jobs
+  #        run: |
+  #          echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped"] | any($result == .))'
+  #
+  #  deploy-status-check:
+  #    runs-on: ubuntu-latest
+  #    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm]
+  #    if: false
+  #    steps:
+  #      - name: Check all deploy test jobs
+  #        run: |
+  #          echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped", "cancelled"] | any($result == .))'
+  #
+  operator:
+    needs: changed-files
+    if: false
+    name: Operator
+    runs-on: prod-default-v2
+    env:
+      IMAGE_REGISTRY: ai-dynamo
+      IMAGE_REPOSITORY: dynamo
+      ECR_HOSTNAME: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+    outputs:
+      operator_default_tag: ${{ steps.build-and-push-image.outputs.operator_default_tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - name: Initialize Dynamo Builder
+        uses: ./.github/actions/init-dynamo-builder
+        with:
+          builder_name: ${{ needs.changed-files.outputs.builder_name }}
+          flavor: general
+          arch: 'linux/amd64,linux/arm64'
+      - name: Docker Login
+        uses: ./.github/actions/docker-login
+        with:
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+      - name: Linter
+        shell: bash
+        working-directory: ./deploy/operator
+        run: |
+          docker buildx build --platform linux/arm64 --target linter --progress=plain --build-arg DOCKER_PROXY=${ECR_HOSTNAME}/dockerhub/ --build-context snapshot=../snapshot .
+      - name: Tester
+        shell: bash
+        working-directory: ./deploy/operator
+        run: |
+          docker buildx build --platform linux/arm64 --target tester --progress=plain --build-arg DOCKER_PROXY=${ECR_HOSTNAME}/dockerhub/ --build-context snapshot=../snapshot .
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version: '1.25'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Python dependencies for operator codegen
+        shell: bash
+        working-directory: ./deploy/operator
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pydantic>=2,<3" "black==23.1.0" "pyyaml>=6.0"
+      - name: Check for uncommitted changes
+        shell: bash
+        working-directory: ./deploy/operator
+        run: |
+          make check
+      - name: Build and push Container
+        id: build-and-push-image
+        shell: bash
+        working-directory: ./deploy/operator
+        env:
+          NO_CACHE_FLAG: '' # placeholder for future logic to add no cache flag if needed
+        run: |
+          ECR_DEFAULT_IMAGE_BASE="${ECR_HOSTNAME}/${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}"
+          DEFAULT_TAG="${{ github.sha }}-operator"
+          ACR_IMAGE_BASE="${{ secrets.AZURE_ACR_HOSTNAME }}/${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}"
+          IMAGE_URIS=(
+            "${ECR_DEFAULT_IMAGE_BASE}:${DEFAULT_TAG}"
+            "${ACR_IMAGE_BASE}:${DEFAULT_TAG}"
+          )
+
+          echo "operator_default_tag=${DEFAULT_TAG}" >> $GITHUB_OUTPUT
+          TAGGING_FLAGS=$(printf -- '-t %s ' "${IMAGE_URIS[@]}")
+          echo "flags for docker buildx: ${TAGGING_FLAGS}"
+
+          if [[ "$NO_CACHE_FLAG" == "true" ]]; then
+            NO_CACHE_FLAG="--no-cache"
+          fi
+          docker buildx build --push ${NO_CACHE_FLAG} \
+              --platform linux/amd64,linux/arm64 \
+              --build-arg DOCKER_PROXY=${ECR_HOSTNAME}/dockerhub/ \
+              --build-context snapshot=../snapshot \
+              ${TAGGING_FLAGS} -f Dockerfile .
+
+          echo "### 🐳 Operator Container Images" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Image URI |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|" >> $GITHUB_STEP_SUMMARY
+          for image_uri in "${IMAGE_URIS[@]}"; do
+            echo "| \`${image_uri}\` |" >> $GITHUB_STEP_SUMMARY
+          done
+
+  # ============================================================================
+  # BUILD PIPELINES
+  # ============================================================================
+
+  vllm-build:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: vllm
+      target: runtime
+      version_selector: '["xpu"]'
+      platform: 'linux/amd64'
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: 60
+      use_runner_docker_builder: true
+      fresh_builder: false
+      use_sccache: false
+      push_image: false
+      dynamo_repo: VincyZhang/dynamo
+      dynamo_ref: enbale_xpu_ci
+    secrets: inherit
+
+  vllm-dev-build:
+    name: vllm-dev
+    needs: [changed-files]
+    if: false
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: vllm
+      target: dev
+      version_selector: '["12.9", "13.0"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      push_image: false
+      build_timeout_minutes: 60
+    secrets: inherit
+
+  sglang-build:
+    name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
+    needs: [changed-files]
+    if: false
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: sglang
+      target: runtime
+      version_selector: '["12.9", "13.0"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      build_timeout_minutes: 60
+    secrets: inherit
+
+  sglang-dev-build:
+    name: sglang-dev
+    needs: [changed-files]
+    if: false
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: sglang
+      target: dev
+      version_selector: '["12.9", "13.0"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      push_image: false
+      build_timeout_minutes: 60
+    secrets: inherit
+
+  trtllm-build:
+    name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
+    needs: [changed-files]
+    if: false
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: trtllm
+      target: runtime
+      version_selector: '["13.1"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      build_timeout_minutes: 60
+    secrets: inherit
+
+  trtllm-dev-build:
+    name: trtllm-dev
+    needs: [changed-files]
+    if: false
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: trtllm
+      target: dev
+      version_selector: '["13.1"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      push_image: false
+      build_timeout_minutes: 60
+    secrets: inherit
+
+  planner-build:
+    name: planner # This name overlaps with other planner jobs to group them in the UI
+    needs: [changed-files]
+    if: false
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: dynamo
+      target: planner
+      version_selector: '["cpu"]'
+      platform: 'linux/amd64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      build_timeout_minutes: 45
+    secrets: inherit
+
+  # ============================================================================
+  # TEST PIPELINES
+  # ============================================================================
+
+  vllm-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [vllm-build]
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Test
+      amd_runner: prod-tester-amd-gpu-v1 # This runner is overridden for ARM platform
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      version_selector: '["xpu"]'
+      platform: '["amd64"]' # arm64 for CPU tests, single GPU tests are skipped
+      run_cpu_only_tests: false
+      cpu_only_test_markers: pre_merge and vllm and gpu_0
+      gpu_test_markers: pre_merge and vllm and gpu_1
+      gpu_test_timeout_minutes: 35
+      run_xpu_test: true
+      xpu_test_marker: pre_merge and vllm and xpu_1 and not multimodal
+      xpu_test_timeout_minutes: 120
+    secrets: inherit
+
+  vllm-multi-gpu-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: false
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Multi-GPU Test
+      amd_runner: prod-tester-amd-gpu-4-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      version_selector: '["12.9", "13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4)
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  sglang-test:
+    name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
+    needs: [changed-files, sglang-build]
+    if: false
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: sglang
+      test_type: Test
+      amd_runner: prod-tester-amd-gpu-v1 # This runner is overridden for ARM platform
+      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
+      version_selector: '["12.9", "13.0"]'
+      platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
+      run_cpu_only_tests: true
+      cpu_only_test_markers: pre_merge and sglang and gpu_0
+      gpu_test_markers: pre_merge and sglang and gpu_1
+    secrets: inherit
+
+  sglang-multi-gpu-test:
+    name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
+    needs: [changed-files, sglang-build]
+    if: false
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: sglang
+      test_type: Multi-GPU Test
+      amd_runner: prod-tester-amd-gpu-4-v1
+      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
+      version_selector: '["12.9", "13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and sglang and (gpu_2 or gpu_4)
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  trtllm-test:
+    name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
+    needs: [changed-files, trtllm-build]
+    if: false
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: trtllm
+      test_type: Test
+      amd_runner: prod-tester-amd-gpu-v1 # This runner is overridden for ARM platform
+      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
+      version_selector: '["13.1"]'
+      platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
+      run_cpu_only_tests: true
+      cpu_only_test_markers: pre_merge and trtllm and gpu_0
+      gpu_test_markers: pre_merge and trtllm and gpu_1
+    secrets: inherit
+
+  trtllm-multi-gpu-test:
+    name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
+    needs: [changed-files, trtllm-build]
+    if: false
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: trtllm
+      test_type: Multi-GPU Test
+      amd_runner: prod-tester-amd-gpu-4-v1
+      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
+      version_selector: '["13.1"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and trtllm and (gpu_2 or gpu_4)
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  planner-test:
+    name: planner # This name overlaps with other planner jobs to group them in the UI
+    needs: [changed-files, planner-build]
+    if: false
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: planner
+      test_type: CPU Test
+      amd_runner: prod-tester-amd-gpu-v1 # TODO: CPU only DinD runner for dynamo repo
+      target_tag_plain: ${{ needs.planner-build.outputs.target_tag_plain }}
+      version_selector: '["cpu"]'
+      platform: '["amd64"]'
+      run_sanity_check: false
+      run_cpu_only_tests: true
+      cpu_only_test_markers: 'pre_merge and planner and gpu_0'
+      cpu_only_test_timeout_minutes: 30
+      run_gpu_tests: false
+    secrets: inherit
+
+  #  # ============================================================================
+  #  # DYNAMO RUNTIME PIPELINE
+  #  # ============================================================================
+  #
+  #  dynamo-pipeline:
+  #    name: dynamo-runtime
+  #    needs: [changed-files]
+  #    if: false
+  #    uses: ./.github/workflows/dynamo-pipeline.yml
+  #    with:
+  #      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+  #      cpu_parallel_test_markers: 'pre_merge and parallel and not (vllm or sglang or trtllm) and (gpu_0)'
+  #      cpu_sequential_test_markers: 'pre_merge and not parallel and not (vllm or sglang or trtllm) and (gpu_0)'
+  #      gpu_test_markers: 'pre_merge and none and gpu_1'
+  #    secrets: inherit
+  #
+  #  # ============================================================================
+  #  # IMAGE COMPLIANCE PIPELINES
+  #  # ============================================================================
+  #
+  #  vllm-compliance:
+  #    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+  #    needs: [changed-files, vllm-build]
+  #    if: false
+  #    uses: ./.github/workflows/shared-compliance.yml
+  #    with:
+  #      framework: vllm
+  #      target: runtime
+  #      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+  #      version_selector: '["12.9", "13.0", "cpu", "xpu"]'
+  #      platform: '["amd64"]'
+  #    secrets: inherit
+  #
+  #  sglang-compliance:
+  #    name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
+  #    needs: [changed-files, sglang-build]
+  #    if: false
+  #    uses: ./.github/workflows/shared-compliance.yml
+  #    with:
+  #      framework: sglang
+  #      target: runtime
+  #      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
+  #      version_selector: '["12.9", "13.0"]'
+  #      platform: '["amd64"]'
+  #    secrets: inherit
+  #
+  #  trtllm-compliance:
+  #    name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
+  #    needs: [changed-files, trtllm-build]
+  #    if: false
+  #    uses: ./.github/workflows/shared-compliance.yml
+  #    with:
+  #      framework: trtllm
+  #      target: runtime
+  #      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
+  #      version_selector: '["13.1"]'
+  #      platform: '["amd64"]'
+  #    secrets: inherit
+  #
+  #  planner-compliance:
+  #    name: planner # This name overlaps with other planner jobs to group them in the UI
+  #    needs: [changed-files, planner-build]
+  #    if: false
+  #    uses: ./.github/workflows/shared-compliance.yml
+  #    with:
+  #      framework: dynamo
+  #      target: planner
+  #      target_tag_plain: ${{ needs.planner-build.outputs.target_tag_plain }}
+  #      version_selector: '["cpu"]'
+  #      platform: '["amd64"]'
+  #    secrets: inherit
+  #
+  #  # ============================================================================
+  #  # IMAGE COPY PIPELINES
+  #  # ============================================================================
+  #
+  #  vllm-copy-to-acr:
+  #    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+  #    needs: [changed-files, vllm-build, vllm-test]
+  #    if: false
+  #    uses: ./.github/workflows/shared-copy.yml
+  #    with:
+  #      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+  #      version_selector: '["12.9", "13.0", "xpu"]'
+  #      override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
+  #      copy_timeout_minutes: 10
+  #    secrets: inherit
+  #
+  #  sglang-copy-to-acr:
+  #    name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
+  #    needs: [changed-files, sglang-build, sglang-test]
+  #    if: false
+  #    uses: ./.github/workflows/shared-copy.yml
+  #    with:
+  #      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
+  #      version_selector: '["12.9", "13.0"]'
+  #      override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
+  #      copy_timeout_minutes: 10
+  #    secrets: inherit
+  #
+  #  trtllm-copy-to-acr:
+  #    name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
+  #    needs: [changed-files, trtllm-build, trtllm-test]
+  #    if: false
+  #    uses: ./.github/workflows/shared-copy.yml
+  #    with:
+  #      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
+  #      version_selector: '["13.1"]'
+  #      override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
+  #      copy_timeout_minutes: 10
+  #    secrets: inherit
+  #
+  #  # ============================================================================
+  #  # DEPLOY TEST PIPELINES
+  #  # ============================================================================
+  #
+  #  deploy-operator:
+  #    if: false
+  #    needs: [changed-files, operator]
+  #    runs-on: prod-default-small-v2
+  #    outputs:
+  #      namespace: ${{ steps.setup.outputs.namespace }}
+  #      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+  #      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+  #    steps:
+  #      - uses: actions/checkout@v4
+  #      - name: Setup vCluster and operator
+  #        id: setup
+  #        uses: ./.github/actions/setup-dynamo-operator
+  #        with:
+  #          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
+  #          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+  #          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+  #          hf_token: ${{ secrets.HF_TOKEN }}
+  #          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+  #          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+  #
+  #  deploy-test-vllm:
+  #    name: vllm Deploy Test
+  #    needs: [changed-files, deploy-operator, vllm-copy-to-acr, vllm-multi-gpu-test]
+  #    if: false
+  #    uses: ./.github/workflows/shared-deploy-test.yml
+  #    with:
+  #      framework: vllm
+  #      profiles: '["agg", "agg_router", "disagg", "disagg_router"]'
+  #      image_suffix: vllm-runtime-cuda12
+  #      namespace: ${{ needs.deploy-operator.outputs.namespace }}
+  #      vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+  #      operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+  #    secrets: inherit
+  #
+  #  deploy-test-sglang:
+  #    name: sglang Deploy Test
+  #    needs: [changed-files, deploy-operator, sglang-copy-to-acr, sglang-multi-gpu-test]
+  #    if: false
+  #    uses: ./.github/workflows/shared-deploy-test.yml
+  #    with:
+  #      framework: sglang
+  #      profiles: '["agg", "agg_router"]'
+  #      image_suffix: sglang-runtime-cuda12
+  #      namespace: ${{ needs.deploy-operator.outputs.namespace }}
+  #      vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+  #      operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+  #    secrets: inherit
+  #
+  #  deploy-test-trtllm:
+  #    name: trtllm Deploy Test
+  #    needs: [changed-files, deploy-operator, trtllm-copy-to-acr, trtllm-multi-gpu-test]
+  #    if: false
+  #    uses: ./.github/workflows/shared-deploy-test.yml
+  #    with:
+  #      framework: trtllm
+  #      profiles: '["agg", "agg_router"]'
+  #      image_suffix: trtllm-runtime-cuda13
+  #      namespace: ${{ needs.deploy-operator.outputs.namespace }}
+  #      vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+  #      operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+  #    secrets: inherit
+  #
+  #  deploy-cleanup:
+  #    if: false
+  #    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm]
+  #    runs-on: prod-default-small-v2
+  #    steps:
+  #      - uses: actions/checkout@v4
+  #      - name: Teardown vCluster
+  #        if: needs.deploy-operator.outputs.namespace != '' && needs.deploy-operator.outputs.vcluster_name != ''
+  #        uses: ./.github/actions/teardown-dynamo-operator
+  #        with:
+  #          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
+  #          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+  #          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+  #
+  #  clean-k8s-builder:
+  #    name: Clean K8s builder if exists
+  #    runs-on: prod-default-small-v2
+  #    if: false
+  #    needs:
+  #      - changed-files
+  #      - operator
+  #      - planner-test
+  #      - vllm-copy-to-acr
+  #      - vllm-multi-gpu-test
+  #      - sglang-copy-to-acr
+  #      - sglang-multi-gpu-test
+  #      - trtllm-copy-to-acr
+  #      - trtllm-multi-gpu-test
+  #    steps:
+  #      - name: Checkout repository
+  #        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+  #      - name: Create K8s builders (skip bootstrap)
+  #        uses: ./.github/actions/bootstrap-buildkit
+  #        continue-on-error: true
+  #        with:
+  #          builder_name: ${{ needs.changed-files.outputs.builder_name }}
+  #          buildkit_worker_addresses: ''
+  #          skip_bootstrap: true
+  #      - name: Builder Cleanup in case of k8s builder
+  #        shell: bash
+  #        run: |
+  #          docker buildx rm ${{ needs.changed-files.outputs.builder_name }} || true
+  #
+  #  # ============================================================================
+  #  # ALLURE REPORT
+  #  # Generate Allure test report and deploy to GitHub Pages
+  #  # ============================================================================
+  #
+  #  allure-report:
+  #    needs:
+  #      - changed-files
+  #      - operator
+  #      - vllm-build
+  #      - vllm-test
+  #      - vllm-multi-gpu-test
+  #      - vllm-copy-to-acr
+  #      - sglang-build
+  #      - sglang-test
+  #      - sglang-multi-gpu-test
+  #      - sglang-copy-to-acr
+  #      - trtllm-build
+  #      - trtllm-test
+  #      - trtllm-multi-gpu-test
+  #      - trtllm-copy-to-acr
+  #      - deploy-test-vllm
+  #      - deploy-test-sglang
+  #      - deploy-test-trtllm
+  #    if: false
+  #    # Disabled: gh-pages branch bloated to ~1GB after 72 commits of Allure reports
+  #    # if: ${{ !cancelled() }}
+  #    uses: ./.github/workflows/generate-allure-report.yml
+  #    with:
+  #      run_id: ${{ github.run_id }}
+  #      subdir: pr
+  #      workflow_label: PR
+  #    permissions:
+  #      contents: write
+  #      actions: read

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -192,8 +192,8 @@ jobs:
           IMAGE_TAG=${{ github.sha }}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}
           TEST_IMAGE_TAG=${{ github.sha }}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}-test
 
-          IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${IMAGE_TAG}"
-          TEST_IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${TEST_IMAGE_TAG}"
+          IMAGE_URI="dynamo:${IMAGE_TAG}"
+          TEST_IMAGE_URI="dynamo:${TEST_IMAGE_TAG}"
           echo "target_tag_plain=${TARGET_TAG_PLAIN}" >> $GITHUB_OUTPUT
           echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
           echo "test_image_uri=${TEST_IMAGE_URI}" >> $GITHUB_OUTPUT
@@ -221,12 +221,11 @@ jobs:
         env:
           EXTRA_TAGS: ${{ inputs.extra_tags }}
         run: |
-          ECR_REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com"
           RESULT=""
           if [ -n "$EXTRA_TAGS" ]; then
             while IFS= read -r tag; do
               if [ -n "$tag" ]; then
-                RESULT+="${ECR_REGISTRY}/ai-dynamo/dynamo:${tag}"$'\n'
+                RESULT+="dynamo:${tag}"$'\n'
               fi
             done <<< "$EXTRA_TAGS"
           fi
@@ -311,18 +310,8 @@ jobs:
       - name: Build and Push Test Image
         if: ${{ inputs.target != 'dev' }}
         shell: bash
-        env:
-          ECR_HOSTNAME: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
         run: |
-          PLAIN_TAG="${{ steps.calculate-target-tag.outputs.target_tag_plain }}"
-          CACHE_TAG="test-${PLAIN_TAG}-cache"
-          CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG}"
-          CACHE_ARGS+=" --cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG}"
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            CACHE_ARGS+=" --cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max"
-          elif [[ "$GITHUB_REF_NAME" =~ ^release ]]; then
-            CACHE_ARGS+=" --cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG},mode=max"
-          fi
+          CACHE_ARGS=""
 
           PUSH_ARGS=""
           if [ "${{ inputs.push_image }}" == "true" ]; then

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -106,7 +106,7 @@ on:
         description: 'Git ref (branch/tag/sha) of the dynamo repo to checkout'
         required: false
         type: string
-        default: 'enbale_xpu_ci'
+        default: 'enable_more_xpu_test'
     secrets:
       AWS_DEFAULT_REGION:
         required: false

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Shared Build Image
+
+on:
+  workflow_call:
+    inputs:
+      framework:
+        description: 'Framework name (vllm, sglang, trtllm)'
+        required: true
+        type: string
+      target:
+        description: 'Target stage for Docker rendering'
+        required: false
+        type: string
+        default: 'runtime'
+      version_selector:
+        description: 'Runtime version selectors to build as a JSON array (e.g. cuda versions, cpu, xpu)'
+        required: true
+        type: string
+      platform:
+        description: 'Target platforms to build as a JSON array'
+        required: true
+        type: string
+      builder_name:
+        description: 'Buildkit builder name'
+        required: true
+        type: string
+      build_timeout_minutes:
+        description: 'Timeout in minutes for the build step'
+        required: false
+        type: number
+        default: 60
+      extra_tags:
+        description: 'Additional tags (newline-separated, -$platform suffix auto-appended)'
+        required: false
+        type: string
+        default: ''
+      no_cache:
+        description: 'Disable Docker build cache'
+        required: false
+        type: boolean
+        default: false
+      fresh_builder:
+        description: 'Always create a fresh K8s BuildKit builder (skip remote worker routing)'
+        required: false
+        type: boolean
+        default: false
+      use_runner_docker_builder:
+        description: 'Use local runner docker buildx instead of remote K8s BuildKit'
+        required: false
+        type: boolean
+        default: false
+      use_sccache:
+        description: 'Use sccache for build caching (requires AWS credentials)'
+        required: false
+        type: boolean
+        default: false
+      push_image:
+        description: 'Push image to registry'
+        required: false
+        type: boolean
+        default: true
+      no_load:
+        description: 'Do not load the image into docker'
+        required: false
+        type: boolean
+        default: true
+      show_summary:
+        description: 'Show summary'
+        required: false
+        type: boolean
+        default: false
+      make_efa:
+        description: 'Enable AWS EFA support in the build'
+        required: false
+        type: boolean
+        default: false
+      sanitized_ref_name:
+        description: 'Sanitized git ref name for branch-tagged images'
+        required: false
+        type: string
+        default: ''
+      build_only:
+        description: 'Build and push only — skip tests and prepare branch tags'
+        required: false
+        type: boolean
+        default: false
+      extra_build_args:
+        description: 'Extra build args to pass to docker build (newline-separated)'
+        required: false
+        type: string
+        default: ''
+      dev_version_suffix:
+        description: 'PEP 440 dev suffix (e.g. .dev20260423+g1234567). Empty = stable build.'
+        required: false
+        type: string
+        default: ''
+      dynamo_repo:
+        description: 'Dynamo source repository (owner/repo) to checkout for build context'
+        required: false
+        type: string
+        default: 'VincyZhang/dynamo'
+      dynamo_ref:
+        description: 'Git ref (branch/tag/sha) of the dynamo repo to checkout'
+        required: false
+        type: string
+        default: 'enbale_xpu_ci'
+    secrets:
+      AWS_DEFAULT_REGION:
+        required: false
+      AWS_ACCOUNT_ID:
+        required: false
+      AZURE_ACR_HOSTNAME:
+        required: false
+      AZURE_ACR_USER:
+        required: false
+      AZURE_ACR_PASSWORD:
+        required: false
+      SCCACHE_S3_BUCKET:
+        required: false
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      HF_TOKEN:
+        required: false
+    outputs:
+      target_tag_plain:
+        description: 'Plain runtime image tag prefix'
+        value: ${{ jobs.build.outputs.target_tag_plain }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        version_selector: ${{ fromJson(inputs.version_selector) }}
+    runs-on: ${{ matrix.version_selector == 'xpu' && 'xpu' || 'prod-builder-v3' }}
+    # version_selector not empty -- name: cuda12, linux/amd64
+    # version_selector cpu/empty -- name: cpu, linux/amd64
+    name: Build multi-arch ${{ matrix.version_selector == 'xpu' && 'xpu' || (matrix.version_selector == '' || matrix.version_selector == 'cpu') && 'cpu' || format('cuda{0}', matrix.version_selector) }}
+    outputs:
+      target_tag_plain: ${{ steps.calculate-target-tag.outputs.target_tag_plain }}
+      test_tag_plain: ${{ steps.calculate-target-tag.outputs.test_tag_plain }}
+    steps:
+      - name: Checkout CI repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          lfs: true
+      - name: Checkout dynamo source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ inputs.dynamo_repo }}
+          ref: ${{ inputs.dynamo_ref }}
+          path: dynamo-src
+          lfs: true
+      - name: Overlay dynamo source
+        shell: bash
+        run: |
+          # Overlay dynamo source into working directory, preserving .github/ from CI repo
+          rsync -a --exclude='.github' --exclude='.git' dynamo-src/ ./
+          rm -rf dynamo-src
+      #- name: Docker Login
+      #  uses: ./.github/actions/docker-login
+      #  with:
+      #    aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      #    aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+      #    azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+      #    azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+      #    azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+      - name: Calculate target tag
+        id: calculate-target-tag
+        shell: bash
+        run: |
+          TAG_BUILDER=${{ inputs.framework }}-${{ inputs.target }}
+          IMAGE_TAG_SUFFIX=""
+          if [ "${{ inputs.make_efa }}" == "true" ]; then
+            TAG_BUILDER+="-efa"
+          fi
+          TARGET_TAG_PLAIN=${TAG_BUILDER}
+          if [ "${{ matrix.version_selector }}" == "xpu" ]; then
+            IMAGE_TAG_SUFFIX="-xpu"
+          elif [ "${{ matrix.version_selector }}" == "cpu" ]; then
+            IMAGE_TAG_SUFFIX=""
+          elif [ "${{ matrix.version_selector }}" != "" ]; then
+            CUDA_VERSION="${{ matrix.version_selector }}"
+            CUDA_MAJOR=${CUDA_VERSION%%.*}
+            IMAGE_TAG_SUFFIX="-cuda${CUDA_MAJOR}"
+          fi
+          IMAGE_TAG=${{ github.sha }}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}
+          TEST_IMAGE_TAG=${{ github.sha }}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}-test
+
+          IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${IMAGE_TAG}"
+          TEST_IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${TEST_IMAGE_TAG}"
+          echo "target_tag_plain=${TARGET_TAG_PLAIN}" >> $GITHUB_OUTPUT
+          echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
+          echo "test_image_uri=${TEST_IMAGE_URI}" >> $GITHUB_OUTPUT
+      - name: Calculate Builder Flavor
+        id: calculate-builder-flavor
+        shell: bash
+        run: |
+          if [[ ${{ inputs.framework }} != @(vllm|sglang|trtllm) ]]; then
+            echo "builder_flavor=general" >> $GITHUB_OUTPUT
+          else
+            echo "builder_flavor=${{ inputs.framework }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Initialize Dynamo Builder
+        uses: ./.github/actions/init-dynamo-builder
+        with:
+          builder_name: ${{ inputs.builder_name }}
+          flavor: ${{ steps.calculate-builder-flavor.outputs.builder_flavor }}
+          arch: ${{ matrix.version_selector == 'xpu' && 'linux/amd64' || inputs.platform }}
+          cuda_version: ${{ (matrix.version_selector == 'xpu' || matrix.version_selector == 'cpu') && '' || matrix.version_selector }}
+          fresh_builder: ${{ inputs.fresh_builder }}
+          use_runner_docker_builder: ${{ inputs.use_runner_docker_builder }}
+      - name: Calculate extra tags
+        id: extra-tags
+        shell: bash
+        env:
+          EXTRA_TAGS: ${{ inputs.extra_tags }}
+        run: |
+          ECR_REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com"
+          RESULT=""
+          if [ -n "$EXTRA_TAGS" ]; then
+            while IFS= read -r tag; do
+              if [ -n "$tag" ]; then
+                RESULT+="${ECR_REGISTRY}/ai-dynamo/dynamo:${tag}"$'\n'
+              fi
+            done <<< "$EXTRA_TAGS"
+          fi
+          if [ -n "$RESULT" ]; then
+            echo "tags<<EOF" >> $GITHUB_OUTPUT
+            echo "$RESULT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "tags=" >> $GITHUB_OUTPUT
+          fi
+      - name: Print Build Container inputs
+        shell: bash
+        run: |
+          echo "=== Build Container Inputs ==="
+          echo "image_uri: ${{ steps.calculate-target-tag.outputs.image_uri }}"
+          echo "framework: ${{ inputs.framework }}"
+          echo "device: ${{ matrix.version_selector == 'xpu' && 'xpu' || matrix.version_selector == 'cpu' && 'cpu' || 'cuda' }}"
+          echo "target: ${{ inputs.target }}"
+          echo "platform: ${{ matrix.version_selector == 'xpu' && 'linux/amd64' || inputs.platform }}"
+          echo "no_cache: ${{ inputs.no_cache }}"
+          echo "extra_tags: ${{ steps.extra-tags.outputs.tags }}"
+          echo "push_image: ${{ inputs.push_image }}"
+          echo "no_load: ${{ inputs.no_load }}"
+          echo "build_timeout_minutes: ${{ inputs.build_timeout_minutes }}"
+      - name: Generate Dockerfile
+        shell: bash
+        run: |
+          echo "Generating Dockerfile for target: ${{ inputs.target }} and framework: ${{ inputs.framework }}"
+          MAKE_EFA_FLAG=""
+          if [ "${{ inputs.make_efa }}" == "true" ]; then
+            MAKE_EFA_FLAG="--make-efa"
+          fi
+          # If CUDA version is empty, use empty arg to fallback to default (eg. for planner)
+          if [ "${{ matrix.version_selector }}" == "xpu" ] || [ "${{ matrix.version_selector }}" == "cpu" ]; then
+            CUDA_FLAG=""
+          else
+            CUDA_FLAG="--cuda-version=${{ matrix.version_selector }}"
+          fi
+
+          python ./container/render.py \
+              --target=${{ inputs.target }} \
+              --framework=${{ inputs.framework }} \
+              --platform=${{ matrix.version_selector == 'xpu' && 'linux/amd64' || inputs.platform }} \
+              --device=${{ matrix.version_selector == 'xpu' && 'xpu' || 'cuda' }} \
+              ${CUDA_FLAG} \
+              ${MAKE_EFA_FLAG} \
+              --show-result \
+              --output-short-filename
+      - name: Apply nightly dev version
+        if: inputs.dev_version_suffix != ''
+        shell: bash
+        run: python3 .github/scripts/apply_dev_version.py "${{ inputs.dev_version_suffix }}" .
+      - name: Build and Push Image
+        id: build-image
+        uses: ./.github/actions/docker-remote-build
+        with:
+          image_tag: ${{ steps.calculate-target-tag.outputs.image_uri }}
+          framework: ${{ inputs.framework }}
+          target: ${{ inputs.target }}
+          platform: ${{ matrix.version_selector == 'xpu' && 'linux/amd64' || inputs.platform }}
+          device: ${{ matrix.version_selector == 'xpu' && 'xpu' || matrix.version_selector == 'cpu' && 'cpu' || 'cuda' }}
+          cuda_version: ${{ matrix.version_selector }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          sccache_s3_bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          no_cache: ${{ inputs.no_cache }}
+          extra_tags: ${{ steps.extra-tags.outputs.tags }}
+          push_image: ${{ inputs.push_image }}
+          no_load: ${{ inputs.no_load }}
+          use_sccache: ${{ inputs.use_sccache }}
+          extra_build_args: |
+            DYNAMO_COMMIT_SHA=${{ github.sha }}
+            ${{ inputs.extra_build_args }}
+      - name: Refresh BuildKit builder
+        if: ${{ inputs.target != 'dev' && inputs.use_runner_docker_builder != true }}
+        uses: ./.github/actions/builder-refresher
+        with:
+          builder_name: ${{ inputs.builder_name }}
+          flavor: ${{ steps.calculate-builder-flavor.outputs.builder_flavor }}
+          arch: ${{ inputs.platform }}
+          cuda_version: ${{ matrix.version_selector }}
+      - name: Build and Push Test Image
+        if: ${{ inputs.target != 'dev' }}
+        shell: bash
+        env:
+          ECR_HOSTNAME: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+        run: |
+          PLAIN_TAG="${{ steps.calculate-target-tag.outputs.target_tag_plain }}"
+          CACHE_TAG="test-${PLAIN_TAG}-cache"
+          CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG}"
+          CACHE_ARGS+=" --cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG}"
+          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+            CACHE_ARGS+=" --cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max"
+          elif [[ "$GITHUB_REF_NAME" =~ ^release ]]; then
+            CACHE_ARGS+=" --cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG},mode=max"
+          fi
+
+          PUSH_ARGS=""
+          if [ "${{ inputs.push_image }}" == "true" ]; then
+            PUSH_ARGS="--push"
+          elif [ "${{ inputs.no_load }}" == "false" ]; then
+            PUSH_ARGS="--load"
+          fi
+
+          NO_CACHE_ARG=""
+          if [ "${{ inputs.no_cache }}" == "true" ]; then
+            NO_CACHE_ARG="--no-cache"
+          fi
+
+          docker buildx build \
+            --progress=plain \
+            --builder "${BUILDX_BUILDER_NAME:-default}" \
+            ${PUSH_ARGS} \
+            ${NO_CACHE_ARG} \
+            --platform ${{ matrix.version_selector == 'xpu' && 'linux/amd64' || inputs.platform }} \
+            -f container/Dockerfile.test \
+            --build-arg BASE_IMAGE=${{ steps.calculate-target-tag.outputs.image_uri }} \
+            ${CACHE_ARGS} \
+            -t ${{ steps.calculate-target-tag.outputs.test_image_uri }} .
+      - name: Show summary
+        shell: bash
+        if: ${{ inputs.push_image == 'true' && inputs.show_summary == 'true' }}
+        run: |
+          echo "### 🐳 ${{ steps.calculate-target-tag.outputs.target_tag_plain }} Default Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Image URI |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| \`${{ steps.calculate-target-tag.outputs.image_uri }}\` |" >> $GITHUB_STEP_SUMMARY
+          EXTRA_TAGS="${{ steps.extra-tags.outputs.tags }}"
+          if [ -n "$EXTRA_TAGS" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### 🏷️ Extra Tags" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Image URI |" >> $GITHUB_STEP_SUMMARY
+            echo "|-----|" >> $GITHUB_STEP_SUMMARY
+            while IFS= read -r tag; do
+              if [ -n "$tag" ]; then
+                echo "| \`${tag}\` |" >> $GITHUB_STEP_SUMMARY
+              fi
+            done <<< "$EXTRA_TAGS"
+          fi

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -115,7 +115,7 @@ jobs:
         id: calculate-target-tag
         shell: bash
         env:
-          ECR_REPOSITORY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo
+          ECR_REPOSITORY: dynamo
         run: |
           
           if [[ "${{ matrix.version_selector }}" == "cpu" ]] || [[ "${{ inputs.target_tag_plain }}" == *"planner"* ]]; then

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Shared Local GPU and CPU Test
+
+on:
+  workflow_call:
+    inputs:
+      test_suite_name:
+        description: 'Test suite name (vllm, sglang, trtllm)'
+        required: true
+        type: string
+      test_type:
+        description: 'Test type (e.g. single-gpu, multi-gpu)'
+        required: true
+        type: string
+      amd_runner:
+        description: 'Runner to execute tests on (amd64 only)'
+        required: true
+        type: string
+      target_tag_plain:
+        description: 'Plain runtime image tag prefix from the build workflow'
+        required: true
+        type: string
+      version_selector:
+        description: 'Runtime version selectors to test as a JSON array (e.g. cuda versions, cpu, xpu)'
+        required: true
+        type: string
+      platform:
+        description: 'Target platforms to test as a JSON array'
+        required: true
+        type: string
+      run_sanity_check:
+        description: 'Whether to run sanity check on the runtime image before executing tests'
+        required: false
+        type: boolean
+        default: true
+      run_cpu_only_tests:
+        description: 'Whether to run CPU-only tests'
+        required: false
+        type: boolean
+        default: false
+      cpu_only_test_markers:
+        description: 'CPU-only pytest markers'
+        required: false
+        type: string
+      cpu_only_test_timeout_minutes:
+        description: 'Timeout in minutes for CPU tests'
+        required: false
+        type: number
+        default: 10
+      cpu_parallel_mode:
+        description: 'pytest-xdist mode for CPU-only tests: auto, none/0, or a worker count'
+        required: false
+        type: string
+        default: 'auto'
+      run_gpu_tests:
+        description: 'Whether to run GPU tests'
+        required: false
+        type: boolean
+        default: true
+      gpu_test_markers:
+        description: 'GPU pytest markers'
+        required: false
+        type: string
+      gpu_test_timeout_minutes:
+        description: 'Timeout in minutes for GPU tests'
+        required: false
+        type: number
+        default: 30
+      run_xpu_test:
+        description: 'Whether to run XPU tests'
+        required: false
+        type: boolean
+        default: false
+      xpu_test_marker:
+        description: 'XPU pytest markers'
+        required: false
+        type: string
+      xpu_test_timeout_minutes:
+        description: 'Timeout in minutes for XPU tests'
+        required: false
+        type: number
+        default: 120
+    secrets:
+      AWS_DEFAULT_REGION:
+        required: false
+      AWS_ACCOUNT_ID:
+        required: false
+      AZURE_ACR_HOSTNAME:
+        required: false
+      AZURE_ACR_USER:
+        required: false
+      AZURE_ACR_PASSWORD:
+        required: false
+      HF_TOKEN:
+        required: false
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(inputs.platform) }}
+        version_selector: ${{ fromJson(inputs.version_selector) }}
+        exclude:
+          - version_selector: xpu
+            platform: arm64
+    name: ${{ inputs.test_type }} ${{ matrix.version_selector == 'cpu' && 'cpu' || matrix.version_selector == 'xpu' && 'xpu' || format('cuda{0}', matrix.version_selector) }}, ${{ matrix.platform }}
+    runs-on: ${{ matrix.version_selector == 'xpu' && 'xpu' || matrix.platform == 'amd64' && inputs.amd_runner || 'prod-tester-arm-v1' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Calculate target tag
+        id: calculate-target-tag
+        shell: bash
+        env:
+          ECR_REPOSITORY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo
+        run: |
+          
+          if [[ "${{ matrix.version_selector }}" == "cpu" ]] || [[ "${{ inputs.target_tag_plain }}" == *"planner"* ]]; then
+            CPU_IMAGE_TAG=${{ github.sha }}-${{ inputs.target_tag_plain }}
+            echo "cpu_runtime_image=${ECR_REPOSITORY}:${CPU_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "cpu_test_image=${ECR_REPOSITORY}:${CPU_IMAGE_TAG}-test" >> $GITHUB_OUTPUT
+            echo "runtime_image=${ECR_REPOSITORY}:${CPU_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "test_image=${ECR_REPOSITORY}:${CPU_IMAGE_TAG}-test" >> $GITHUB_OUTPUT
+            exit 0
+          elif [[ "${{ matrix.version_selector }}" == "xpu" ]]; then
+            XPU_IMAGE_TAG=${{ github.sha }}-${{ inputs.target_tag_plain }}-xpu
+            echo "xpu_runtime_image=${ECR_REPOSITORY}:${XPU_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "xpu_test_image=${ECR_REPOSITORY}:${XPU_IMAGE_TAG}-test" >> $GITHUB_OUTPUT
+            echo "runtime_image=${ECR_REPOSITORY}:${XPU_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "test_image=${ECR_REPOSITORY}:${XPU_IMAGE_TAG}-test" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            CUDA_VERSION="${{ matrix.version_selector }}"
+            CUDA_MAJOR=${CUDA_VERSION%%.*}
+            IMAGE_TAG=${{ github.sha }}-${{ inputs.target_tag_plain }}-cuda${CUDA_MAJOR}
+          fi
+
+          RUNTIME_IMAGE=${ECR_REPOSITORY}:${IMAGE_TAG}
+          TEST_IMAGE=${ECR_REPOSITORY}:${IMAGE_TAG}-test
+          echo "runtime_image=${RUNTIME_IMAGE}" >> $GITHUB_OUTPUT
+          echo "test_image=${TEST_IMAGE}" >> $GITHUB_OUTPUT
+      #- name: Docker Login
+      #  uses: ./.github/actions/docker-login
+      #  with:
+      #    aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      #    aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+      #    azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+      #    azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+      #    azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+      #- name: Pull relevant images
+      #  shell: bash
+      #  run: |
+      #    source ./.github/scripts/retry_docker.sh
+      #    start_time=$(date +%s)
+      #    if [[ "${{ matrix.version_selector }}" == "cpu" ]]; then
+      #      retry_pull ${{ steps.calculate-target-tag.outputs.cpu_runtime_image }}
+      #      retry_pull ${{ steps.calculate-target-tag.outputs.cpu_test_image }}
+      #    elif [[ "${{ matrix.platform }}" == "amd64" && "${{ matrix.version_selector }}" == "xpu" ]]; then
+      #      retry_pull ${{ steps.calculate-target-tag.outputs.xpu_runtime_image }}
+      #      retry_pull ${{ steps.calculate-target-tag.outputs.xpu_test_image }}
+      #    else
+      #      retry_pull ${{ steps.calculate-target-tag.outputs.runtime_image }}
+      #      retry_pull ${{ steps.calculate-target-tag.outputs.test_image }}
+      #    fi
+      #    retry_pull quay.io/minio/minio
+      #    end_time=$(date +%s)
+      #    duration=$((end_time - start_time))
+      #    echo "⏱️ Image pull duration: ${duration}s"
+      #- name: Run Sanity Check on Runtime Image
+      #  if: ${{ inputs.run_sanity_check }}
+      #  shell: bash
+      #  run: |
+      #    echo "Running sanity check on image: ${{ steps.calculate-target-tag.outputs.runtime_image }}"
+#
+      #    export WORKSPACE=/workspace
+#
+      #    set +e
+      #    docker run --rm "${{ steps.calculate-target-tag.outputs.runtime_image }}" python ${WORKSPACE}/deploy/sanity_check.py --runtime-check --no-gpu-check
+      #    SANITY_CHECK_EXIT_CODE=$?
+      #    set -e
+      #    if [ ${SANITY_CHECK_EXIT_CODE} -ne 0 ]; then
+      #      echo "ERROR: Sanity check failed - ai-dynamo packages not properly installed"
+      #      exit ${SANITY_CHECK_EXIT_CODE}
+      #    else
+      #      echo "✅ Sanity check passed"
+      #    fi
+      - name: Run CPU-only tests (parallelized)
+        if: ${{ inputs.run_cpu_only_tests }}
+        timeout-minutes: ${{ inputs.cpu_only_test_timeout_minutes }}
+        uses: ./.github/actions/pytest
+        with:
+          image_tag: ${{ steps.calculate-target-tag.outputs.test_image }}
+          pytest_marks: ${{ inputs.cpu_only_test_markers }}
+          test_suite_name: ${{ inputs.test_suite_name }}
+          test_type: "pre_merge_cpu"
+          platform_arch: ${{ matrix.platform }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          parallel_mode: ${{ inputs.cpu_parallel_mode }}
+          dind_as_sidecar: 'true'
+      - name: Run GPU tests (sequential)
+        timeout-minutes: ${{ inputs.gpu_test_timeout_minutes }}
+        if: ${{ matrix.platform == 'amd64' && inputs.run_gpu_tests && startsWith(matrix.version_selector, 'cuda') }}
+        uses: ./.github/actions/pytest
+        with:
+          image_tag: ${{ steps.calculate-target-tag.outputs.test_image }}
+          pytest_marks: ${{ inputs.gpu_test_markers }}
+          test_suite_name: ${{ inputs.test_suite_name }}
+          test_type: "pre_merge_gpu"
+          platform_arch: ${{ matrix.platform }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          parallel_mode: 'none'
+          dind_as_sidecar: 'true'
+      - name: Run XPU tests (sequential)
+        timeout-minutes: ${{ inputs.xpu_test_timeout_minutes }}
+        if: ${{ matrix.version_selector == 'xpu' && inputs.run_xpu_test }}
+        uses: ./.github/actions/pytest
+        with:
+          image_tag: ${{ steps.calculate-target-tag.outputs.test_image }}
+          pytest_marks: ${{ inputs.xpu_test_marker }}
+          test_suite_name: ${{ inputs.test_suite_name }}
+          test_type: "pre_merge_gpu"
+          platform_arch: ${{ matrix.platform }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          parallel_mode: 'none'
+          dind_as_sidecar: 'true'
+          device: xpu
+
+      - name: Cleanup Docker Images
+        if: ${{ always() && matrix.version_selector == 'xpu' && matrix.platform == 'amd64' && inputs.run_xpu_test }}
+        shell: bash
+        run: |
+          echo "🧹 Cleaning up XPU docker images..."
+          docker image rm -f "${{ steps.calculate-target-tag.outputs.test_image }}" 2>/dev/null || true
+          docker image rm -f "${{ steps.calculate-target-tag.outputs.runtime_image }}" 2>/dev/null || true
+          echo "✓ XPU image cleanup finished"
+      
+      


### PR DESCRIPTION
## Summary

Add GitHub Actions workflows and composite actions to build and test dynamo XPU Docker images.

The pipeline checks out dynamo source from `VincyZhang/dynamo` (`enbale_xpu_ci` branch) and overlays it at build time, preserving `.github/` from this CI repository.

## New files

- **pr.yaml**: PR workflow with only vllm XPU build+test enabled
- **shared-build-image.yml**: Reusable build workflow with dynamo source overlay
- **shared-test.yml**: Reusable test workflow with XPU test support
- **4 composite actions**: bootstrap-buildkit, docker-remote-build, init-dynamo-builder, pytest

## Design decisions

- All non-XPU jobs (sglang, trtllm, planner, operator, deploy) are disabled (`if: false`)
- Build uses runner-local Docker builder (no K8s BuildKit, no ECR push/pull)
- Dynamo source is overlaid via rsync at build time, excluding `.github/` to preserve CI actions/workflows